### PR TITLE
Feature jest minor mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -32,6 +32,18 @@ A prefix argument causes the generated command line to be offered
 for editing, and various customization options influence how some
 of the commands work. See the README.org for detailed information.
 
+* Jest Minor Mode
+Jest minor mode binds compilation-related commands such as =compile-command= and
+=recompile-command= to Jest commands, so that, for example =C-c <RET>=
+(=compile=) runs =jest-popup= and =C-c C-<RET>= (=recompile=) runs
+=jest-repeat=. The commands to run are configurable.
+
+#+begin_src el
+(use-package jest
+  :after (js2-mode)
+  :hook (js2-mode . jest-minor-mode))
+#+end_src
+
 * Jest Popup
 #+BEGIN_SRC
 Switches

--- a/jest.el
+++ b/jest.el
@@ -544,5 +544,26 @@ Example: ‘MyABCThingy.__repr__’ becomes ‘test_my_abc_thingy_repr’."
           (save-buffer)))))
    (t nil)))
 
+(defcustom jest-compile-command 'jest-popup
+  "Command to run when compile and friends are called."
+  :group 'jest
+  :type 'function)
+
+(defcustom jest-repeat-compile-command 'jest-repeat
+  "Command to run when recompile and friends are called."
+  :group 'jest
+  :type 'function)
+
+;;;###autoload
+(define-minor-mode jest-minor-mode
+  "Minor mode to run jest-mode commands for compile and friends."
+  :lighter " Jest Minor"
+  :keymap (let ((jest-minor-mode-keymap (make-sparse-keymap)))
+            (define-key jest-minor-mode-keymap [remap compile] jest-compile-command)
+            (define-key jest-minor-mode-keymap [remap recompile] jest-repeat-compile-command)
+            (define-key jest-minor-mode-keymap [remap projectile-test-project] jest-compile-command)
+            (define-key jest-minor-mode-keymap (kbd "C-c ;") 'jest-file-dwim)
+            jest-minor-mode-keymap))
+
 (provide 'jest)
 ;;; jest.el ends here

--- a/jest.el
+++ b/jest.el
@@ -317,6 +317,9 @@ With a prefix ARG, allow editing."
 
 ;; internal helpers
 
+(fmakunbound 'jest-mode)
+(makunbound 'jest-mode)
+
 (define-derived-mode jest-mode
   comint-mode "jest"
   "Major mode for jest sessions (derived from comint-mode)."

--- a/jest.el
+++ b/jest.el
@@ -323,7 +323,7 @@ With a prefix ARG, allow editing."
 (define-derived-mode jest-mode
   comint-mode "jest"
   "Major mode for jest sessions (derived from comint-mode)."
-  (compilation-setup))
+  (compilation-setup t))
 
 (cl-defun jest--run (&key args file func edit)
   "Run jest for the given arguments."


### PR DESCRIPTION
Adds jest-minor-mode which remaps `compile` and `recompile` to `jest-popup` and `jest-repeat` (but the commands are configurable so you could use, say `jest-file-dwim` instead).