### PR TITLE
Load s.el explicitly for suppressing byte-compile warnings

### DIFF
--- a/jest.el
+++ b/jest.el
@@ -46,6 +46,7 @@
 (require 'dash-functional)
 (require 'magit-popup)
 (require 'projectile)
+(require 's)
 
 (defgroup jest nil
   "jest integration"


### PR DESCRIPTION
```
In end of data:
jest.el:486:1:Warning: the following functions are not known to be defined: s-replace,
    s-join, s-equals-p, s-prefix-p, s-trim, s-snake-case,
    s-replace-regexp, s-chop-suffix, s-chop-prefix
```