### PR TITLE
implement jest-function interactive command

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,8 +23,8 @@ switches, and then run jest using one of the actions.
 - jest (run all tests)
 - jest-file (current file)
 - jest-file-dwim (‘Do what I mean’ for current file)
-- jest-function (current function)
-- jest-function-dwim (‘Do what I mean’ for current function)
+- jest-function (the test function where the pointer is now,
+  fallback to current file)
 - jest-last-failed (rerun previous failures)
 - jest-repeat (repeat last invocation)
 
@@ -64,6 +64,8 @@ Switches
 Options
  =c config file (--config=)
  =k only names matching expression (-t)
+ =p only files matching expression (--testPathPattern )
+ =P only files not matching expression (--testPathIgnorePatterns )
  =o output file (--outputFile=)
  =x exit after N failures or errors (--maxfail=)
 
@@ -72,10 +74,11 @@ Run tests
 
 Run tests for current context
  f Test file           F Test this file
- d Test def/class      D This def/class
+ d Test function
 
 Repeat tests
  r Repeat last test run
 #+END_SRC
+
 * Contributing
 Please create a [[https://github.com/Emiller88/emacs-jest/issues/new][new issue]] or [[https://github.com/Emiller88/emacs-jest/compare][submit a PR]].


### PR DESCRIPTION
Implement `jest-function` command to execute just one test or suite in a test file.

Fixes #5.