### PR TITLE
Remove spaces from minor-mode name

### DIFF
--- a/jest.el
+++ b/jest.el
@@ -531,7 +531,7 @@ This goes from pointer position upwards."
 ;;;###autoload
 (define-minor-mode jest-minor-mode
   "Minor mode to run jest-mode commands for compile and friends."
-  :lighter " Jest Minor"
+  :lighter " Jest"
   :keymap (let ((jest-minor-mode-keymap (make-sparse-keymap)))
             (define-key jest-minor-mode-keymap [remap compile] jest-compile-command)
             (define-key jest-minor-mode-keymap [remap recompile] jest-repeat-compile-command)


### PR DESCRIPTION
I ran into an issue with mouse-1 clicking on "Jest Minor" in the mode line using `jest-minor-mode` where the link is broken across the two words. Turns out this appears to be an issue caused by `powerline`'s handling of the modeline, perhaps relying on the conventions where minor mode lighters don't have spaces?  

I couldn't find this expressly stated in the emacs conventions, but I also couldn't find examples of other modes having spaces in their lighters.  I'm just submitting
this shortening of the lighter for you to consider.