### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/jest.el
+++ b/jest.el
@@ -3,7 +3,7 @@
 ;; URL:  https://github.com/emiller88/emacs-jest/
 ;; Version: 0.1.0
 ;; Keywords: jest, javascript, testing
-;; Package-Requires: ((emacs "24.4") (dash "2.12.0") (dash-functional "2.12.0") (magit-popup "2.12.0") (projectile "0.14.0") (s "1.12.0") (js2-mode "20180301") (cl-lib "0.6.1"))
+;; Package-Requires: ((emacs "24.4") (dash "2.18.0") (magit-popup "2.12.0") (projectile "0.14.0") (s "1.12.0") (js2-mode "20180301") (cl-lib "0.6.1"))
 
 ;; This file is part of GNU Emacs.
 
@@ -43,7 +43,6 @@
 (require 'js2-mode)
 
 (require 'dash)
-(require 'dash-functional)
 (require 'magit-popup)
 (require 'projectile)
 (require 's)


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218