### PR TITLE
Clear test results when new test is shown

### DIFF
--- a/jest.el
+++ b/jest.el
@@ -515,6 +515,20 @@ This goes from pointer position upwards."
   (let ((first-param (car (js2-call-node-args node))))
     (when (js2-string-node-p first-param)
       (js2-string-node-value first-param))))
+
+(defun jest-clear-buffer-after-test-end (inserted-string)
+  (let
+  ((test-end-regex  ".*?Test Suites:.+\nTests:  .+\nSnapshots: .+\nTime:  .+\nRan all test suites.+\n.*?"))  
+    (when (and (s-contains? "*jest*"
+                            (buffer-name))
+               (s-matches? test-end-regex (buffer-string)))
+      (beginning-of-buffer)
+      (comint-clear-buffer))
+    inserted-string))
+
+
+(add-hook 'comint-preoutput-filter-functions #'jest-clear-buffer-after-test-end)
+
 ;;
 
 (defcustom jest-compile-command 'jest-popup


### PR DESCRIPTION
This is a fix for the github issue to remove previous test info https://github.com/Emiller88/emacs-jest/issues/13

I noticed that at the end of every jest run there is a message "Test Suites and Ran all test suites.",  so I matched that using regex.



the idea came from here https://emacs.stackexchange.com/questions/58960/re-fill-compilation-mode-buffer-from-shell-script