### PR TITLE
Modify project root detection to use package.json

### DIFF
--- a/jest.el
+++ b/jest.el
@@ -414,13 +414,38 @@ Example: ‘MyABCThingy.__repr__’ becomes ‘test_my_abc_thingy_repr’."
 
 ;; file/directory helpers
 
+(defun jest--read-package-json (file)
+  "File to read package json for a project"
+  (json-parse-string (with-temp-buffer
+    (insert-file-contents (jest--find-package-json file))
+    (buffer-string))))
+
+(defun jest--file-search-upward (directory file)
+  "Search DIRECTORY for FILE and return its full path if found, or NIL if not.
+
+If FILE is not found in DIRECTORY, the parent of DIRECTORY will be searched."
+  (let ((parent-dir (file-truename (concat (file-name-directory directory) "../")))
+        (current-path (if (not (string= (substring directory (- (length directory) 1)) "/"))
+                         (concat directory "/" file)
+                         (concat directory file))))
+    (if (file-exists-p current-path)
+        current-path
+        (when (and (not (string= (file-truename directory) parent-dir))
+                   (< (length parent-dir) (length (file-truename directory))))
+          (jest--file-search-upward parent-dir file)))))
+
+(defun jest--find-package-json (file)
+  "Find the package.json associated with a given file"
+  (jest--file-search-upward (file-name-directory file) "package.json"))
+
 (defun jest--project-name ()
   "Find the project name."
-  (projectile-project-name))
+  (gethash "name" (jest--read-package-json buffer-file-name)))
 
 (defun jest--project-root ()
+  (interactive)
   "Find the project root directory."
-  (projectile-project-root))
+  (file-name-directory (jest--find-package-json buffer-file-name)))
 
 (defun jest--relative-file-name (file)
   "Make FILE relative to the project root."


### PR DESCRIPTION
In playing with emacs-jest for one of my projects, I found that it didn't play nice with front end code bases that were nested inside of a larger server side codebase. Instead of using projectile to determine the project root, this PR changes things to look forward a package.json file up the directory tree from the current buffer. Once it finds one it uses that for the root.

This is working well for me locally, so I think it could help others in the same situation.