### PR TITLE
Make test always refresh the directory for the corresponding project / buffer

### DIFF
--- a/README.org
+++ b/README.org
@@ -44,6 +44,17 @@ Jest minor mode binds compilation-related commands such as =compile-command= and
   :hook (js2-mode . jest-minor-mode))
 #+end_src
 
+* Customization
+** jest-transform-arguments
+By default, jest.el transforms command-line arguments before passing them to jest
+(e.g., converting ~--color~ to ~--color=yes~ or ~--color=no~). 
+
+If you prefer to pass arguments to jest without transformation, you can disable this:
+
+#+begin_src el
+(setq jest-transform-arguments nil)
+#+end_src
+
 * Jest Popup
 #+BEGIN_SRC
 Switches

--- a/README.org
+++ b/README.org
@@ -44,17 +44,6 @@ Jest minor mode binds compilation-related commands such as =compile-command= and
   :hook (js2-mode . jest-minor-mode))
 #+end_src
 
-* Customization
-** jest-transform-arguments
-By default, jest.el transforms command-line arguments before passing them to jest
-(e.g., converting ~--color~ to ~--color=yes~ or ~--color=no~). 
-
-If you prefer to pass arguments to jest without transformation, you can disable this:
-
-#+begin_src el
-(setq jest-transform-arguments nil)
-#+end_src
-
 * Jest Popup
 #+BEGIN_SRC
 Switches

--- a/jest.el
+++ b/jest.el
@@ -127,6 +127,14 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
                  (const :tag "Save current buffer" save-current)
                  (const :tag "Ignore" nil)))
 
+(defcustom jest-transform-arguments t
+  "Whether to transform arguments before passing them to jest.
+
+When t (the default), arguments are transformed using `jest--transform-arguments'.
+When nil, arguments are passed to jest without transformation."
+  :group 'jest
+  :type 'boolean)
+
 (defvar jest--history nil
   "History for jest invocations.")
 
@@ -284,7 +292,8 @@ With a prefix ARG, allow editing."
   "Run jest for the given arguments."
   (let ((popup-arguments args)
 	command)
-    (setq args (jest--transform-arguments args))
+    (when jest-transform-arguments
+      (setq args (jest--transform-arguments args)))
     (when (and file (file-name-absolute-p file))
       (setq file (jest--relative-file-name file)))
 

--- a/jest.el
+++ b/jest.el
@@ -127,14 +127,6 @@ When non-nil only ‘test_foo()’ will match, and nothing else."
                  (const :tag "Save current buffer" save-current)
                  (const :tag "Ignore" nil)))
 
-(defcustom jest-transform-arguments t
-  "Whether to transform arguments before passing them to jest.
-
-When t (the default), arguments are transformed using `jest--transform-arguments'.
-When nil, arguments are passed to jest without transformation."
-  :group 'jest
-  :type 'boolean)
-
 (defvar jest--history nil
   "History for jest invocations.")
 
@@ -292,8 +284,7 @@ With a prefix ARG, allow editing."
   "Run jest for the given arguments."
   (let ((popup-arguments args)
 	command)
-    (when jest-transform-arguments
-      (setq args (jest--transform-arguments args)))
+    (setq args (jest--transform-arguments args))
     (when (and file (file-name-absolute-p file))
       (setq file (file-truename file)))
 


### PR DESCRIPTION
why when I trigger the test run in a different project dir, the cwd still showed the previously project (and caused test failed for no test found). The change make it refresh directory, and be able to run the corresponding test